### PR TITLE
Fix ProcessJob bug for results with no terms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'after_commit_everywhere', '~> 0.1', '>= 0.1.5'
 gem 'aws-sdk-s3', require: false
 gem 'bulma-rails', '~> 0.9.0'
 gem 'collectionspace-client', tag: 'v0.7.0', git: 'https://github.com/collectionspace/collectionspace-client.git'
-gem 'collectionspace-mapper', tag: 'v2.1.3', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
+gem 'collectionspace-mapper', tag: 'v2.1.4', git: 'https://github.com/collectionspace/collectionspace-mapper.git'
 gem 'collectionspace-refcache', tag: 'v0.7.2', git: 'https://github.com/collectionspace/collectionspace-refcache.git'
 gem 'csvlint'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,10 @@ GIT
 
 GIT
   remote: https://github.com/collectionspace/collectionspace-mapper.git
-  revision: a2a83f6bfd444886b18a5e2590a79eec6c3ca9d8
-  tag: v2.1.3
+  revision: 7a91431cfea0a6fcfb282ec298b00250ffe4f9ab
+  tag: v2.1.4
   specs:
-    collectionspace-mapper (2.1.3)
+    collectionspace-mapper (2.1.4)
       chronic
       facets
       nokogiri (>= 1.10.9)

--- a/app/jobs/process_job.rb
+++ b/app/jobs/process_job.rb
@@ -55,7 +55,7 @@ class ProcessJob < ApplicationJob
                     message: result.record_status,
                    })
 
-        missing_terms = mts.get_missing(result.terms) unless result.terms.empty?
+        missing_terms = result.terms.empty? ? [] : mts.get_missing(result.terms)
         
         unless missing_terms.empty?
           puts 'Handling missing terms'


### PR DESCRIPTION
 **Fixes bug where job fails here if no terms are returned**

Job on a CSV importing refname values instead of term strings was
failing here because `result.terms` was empty, causing `missing_terms`
to be `nil` instead of empty in the next line.

**Use collectionspace-mapper v2.1.4**

No longer warns about `%NULLVALUE%` being a malformed refname