### PR TITLE
Scope connection to group more strictly

### DIFF
--- a/app/controllers/connections_controller.rb
+++ b/app/controllers/connections_controller.rb
@@ -2,7 +2,6 @@
 
 class ConnectionsController < ApplicationController
   before_action :set_connection, only: %i[edit update destroy]
-  before_action :check_for_connection_targets_another_user, only: %i[new create]
 
   def new
     @connection = Connection.new
@@ -13,6 +12,8 @@ class ConnectionsController < ApplicationController
   def create
     respond_to do |format|
       @connection = Connection.new
+      @connection.user = current_user
+      @connection.group = current_user.group
       if @connection.update(permitted_attributes(@connection))
         format.html do
           redirect_to edit_user_path(current_user)
@@ -49,13 +50,6 @@ class ConnectionsController < ApplicationController
   end
 
   private
-
-  def check_for_connection_targets_another_user
-    user_id = params.dig(:connection, :user_id) || params[:user_id]
-    if user_id.blank? || user_id.to_i != current_user.id
-      raise Pundit::NotAuthorizedError
-    end
-  end
 
   def notice_for_domain(action)
     @connection.domain ? "action.#{action}" : "action.#{action}_disabled"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
+  before_action :set_connections, only: %i[edit update]
   before_action :set_user, only: %i[edit update update_group destroy]
   before_action :check_for_illegal_promote_to_admin, only: %i[update]
 
@@ -11,9 +12,7 @@ class UsersController < ApplicationController
     )
   end
 
-  def edit
-    @connections = @user.connections.order(:name)
-  end
+  def edit; end
 
   def update
     respond_to do |format|
@@ -28,7 +27,6 @@ class UsersController < ApplicationController
                       notice: t('action.updated', record: 'User')
         end
       else
-        @connections = @user.connections.order(:name)
         format.html { render :edit }
       end
     end
@@ -85,6 +83,10 @@ class UsersController < ApplicationController
 
   def reset_user(user)
     current_user.is?(user) ? bypass_sign_in(user) : bypass_sign_in(current_user)
+  end
+
+  def set_connections
+    @connections = current_user.connections.where(group: current_user.group)
   end
 
   def set_user

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,6 +40,10 @@ module ApplicationHelper
     manage?(record)
   end
 
+  def connections_for_batch
+    current_user.connections.where(group: current_user.group)
+  end
+
   def csv_content_types
     Batch.content_types.join(',')
   end

--- a/app/models/connection.rb
+++ b/app/models/connection.rb
@@ -3,8 +3,8 @@
 class Connection < ApplicationRecord
   include PrefixChecker
   belongs_to :user, counter_cache: true
+  belongs_to :group
   has_many :batches, dependent: :nullify # TODO: alrighty?
-  has_one :group, through: :user
   encrypts :password
   before_save :resolve_primary, if: -> { primary? }
   before_save :unset_primary, if: -> { disabled? && primary? }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,8 +41,8 @@ class User < ApplicationRecord
   end
 
   def default_connection
-    connection = connections.where(primary: true).first
-    connection ||= connections.where(enabled: true).first
+    connection = connections.where(group: group, primary: true).first
+    connection ||= connections.where(group: group, enabled: true).first
     connection
   end
 

--- a/app/policies/batch_policy.rb
+++ b/app/policies/batch_policy.rb
@@ -13,7 +13,7 @@ class BatchPolicy < ApplicationPolicy
 
   # a user must have an enabled connection to access the batch create form
   def new?
-    user.connections.where(enabled: true).count.positive?
+    user.connections.where(group: user.group, enabled: true).count.positive?
   end
 
   # defer to step policy

--- a/app/policies/connection_policy.rb
+++ b/app/policies/connection_policy.rb
@@ -18,7 +18,7 @@ class ConnectionPolicy < ApplicationPolicy
   end
 
   def permitted_attributes_for_create
-    %i[name url username password enabled primary profile user_id]
+    %i[name url username password enabled primary profile]
   end
 
   def permitted_attributes_for_update

--- a/app/views/batches/_form.html.erb
+++ b/app/views/batches/_form.html.erb
@@ -29,7 +29,7 @@
         <%= content_tag :div, class: 'column is-half' do %>
           <%= form.label t('batch.connection'), class: 'label' %>
           <div class="select is-fullwidth">
-            <%= form.collection_select :connection_id, current_user.connections,
+            <%= form.collection_select :connection_id, connections_for_batch,
               :id, :name, { selected: @connection.id }, data: { 'reflex': 'change->Connection#selected' }
             %>
           </div>

--- a/app/views/connections/_form.html.erb
+++ b/app/views/connections/_form.html.erb
@@ -97,10 +97,6 @@
         <% end %>
       </div>
 
-      <% if connection.new_record? %>
-        <%= form.hidden_field :user_id, :value => current_user.id %>
-      <% end %>
-
       <div class="field">
         <%= form.label t('connection.domain'), class: 'label' %>
         <%= content_tag :div, class: 'control' do %>

--- a/db/migrate/20200822160258_create_connections.rb
+++ b/db/migrate/20200822160258_create_connections.rb
@@ -10,6 +10,7 @@ class CreateConnections < ActiveRecord::Migration[6.0]
       t.string :domain
       t.string :profile, null: false
       t.references :user, null: false, foreign_key: true
+      t.references :group, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -56,7 +56,7 @@ ActiveRecord::Schema.define(version: 2020_12_03_172131) do
     t.bigint "mapper_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.text "batch_config", default: '{}'
+    t.text "batch_config", default: "{}"
     t.index ["connection_id"], name: "index_batches_on_connection_id"
     t.index ["group_id"], name: "index_batches_on_group_id"
     t.index ["mapper_id"], name: "index_batches_on_mapper_id"
@@ -73,8 +73,10 @@ ActiveRecord::Schema.define(version: 2020_12_03_172131) do
     t.string "domain"
     t.string "profile", null: false
     t.bigint "user_id", null: false
+    t.bigint "group_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["group_id"], name: "index_connections_on_group_id"
     t.index ["user_id"], name: "index_connections_on_user_id"
   end
 
@@ -202,6 +204,7 @@ ActiveRecord::Schema.define(version: 2020_12_03_172131) do
   add_foreign_key "batches", "groups"
   add_foreign_key "batches", "mappers"
   add_foreign_key "batches", "users"
+  add_foreign_key "connections", "groups"
   add_foreign_key "connections", "users"
   add_foreign_key "step_archives", "batches"
   add_foreign_key "step_preprocesses", "batches"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,7 @@ Role.find_or_create_by!(name: 'Admin')
 Role.find_or_create_by!(name: 'Manager')
 Role.find_or_create_by!(name: 'Member')
 
-Group.find_or_create_by!(supergroup: true) do |group|
+default = Group.find_or_create_by!(supergroup: true) do |group|
   group.name = 'Default'
   group.supergroup = true
   group.description = 'Default group.'
@@ -29,7 +29,8 @@ connections = [
     password: 'Administrator',
     enabled: true,
     primary: false,
-    profile: 'core-6.1.0'
+    profile: 'core-6.1.0',
+    group: default
   },
   {
     name: 'Fcart Dev Server',
@@ -38,7 +39,8 @@ connections = [
     password: 'Administrator',
     enabled: true,
     primary: false,
-    profile: 'fcart-3.0.1'
+    profile: 'fcart-3.0.1',
+    group: default
   }
 ]
 

--- a/test/controllers/connections_controller_test.rb
+++ b/test/controllers/connections_controller_test.rb
@@ -21,14 +21,6 @@ class ConnectionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'should not get new when given another users id' do
-    refute_can_view(new_connection_url(user_id: users(:admin).id))
-  end
-
-  test 'should not get new when given no user id' do
-    refute_can_view(new_connection_url)
-  end
-
   test 'should create connection' do
     assert_difference('Connection.count') do
       post connections_url, params: { connection: @valid_params }

--- a/test/fixtures/connections.yml
+++ b/test/fixtures/connections.yml
@@ -10,6 +10,7 @@ core_superuser:
   domain: core.collectionspace.org
   profile: core-6.0.0
   user: superuser
+  group: default
 
 fcart_superuser:
   name: fcart.dev
@@ -21,6 +22,7 @@ fcart_superuser:
   domain: fcart.collectionspace.org
   profile: core-6.0.0
   user: superuser
+  group: default
 
 core_admin:
   name: core.dev
@@ -32,6 +34,7 @@ core_admin:
   domain: core.collectionspace.org
   profile: core-6.0.0
   user: admin
+  group: default
 
 fcart_admin:
   name: fcart.dev
@@ -43,6 +46,7 @@ fcart_admin:
   domain: fcart.collectionspace.org
   profile: core-6.0.0
   user: admin
+  group: default
 
 core_manager:
   name: core.dev
@@ -54,6 +58,7 @@ core_manager:
   domain: core.collectionspace.org
   profile: core-6.0.0
   user: manager
+  group: default
 
 core_minion:
   name: core.dev
@@ -65,6 +70,7 @@ core_minion:
   domain: core.collectionspace.org
   profile: core-6.0.0
   user: minion
+  group: default
 
 core_salmon:
   name: core.dev
@@ -76,3 +82,4 @@ core_salmon:
   domain: core.collectionspace.org
   profile: core-6.0.0
   user: salmon
+  group: fish

--- a/test/fixtures/mappers.yml
+++ b/test/fixtures/mappers.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 anthro_collectionobject_4_0:
-  title: collectionobject (anthro-4-0-0)
+  title: collectionobject (anthro-4.0.0)
   profile: anthro
   type: collectionobject
   version: "4.0.0"
@@ -9,7 +9,7 @@ anthro_collectionobject_4_0:
   status: false
 
 anthro_collectionobject_4_1:
-  title: collectionobject (anthro-4-1-0)
+  title: collectionobject (anthro-4.1.0)
   profile: anthro
   type: collectionobject
   version: "4.1.0"
@@ -17,7 +17,7 @@ anthro_collectionobject_4_1:
   status: true
 
 core_collectionobject_6_0:
-  title: collectionobject (core-6-0-0)
+  title: collectionobject (core-6.0.0)
   profile: core
   type: collectionobject
   version: "6.0.0"

--- a/test/models/connection_test.rb
+++ b/test/models/connection_test.rb
@@ -10,7 +10,8 @@ class ConnectionTest < ActiveSupport::TestCase
       username: 'admin@core.collectionspace.org',
       password: 'Administrator',
       profile: 'core-6.0.0',
-      user_id: users(:superuser).id
+      user_id: users(:superuser).id,
+      group_id: users(:superuser).group_id
     }
   end
 

--- a/test/models/mapper_test.rb
+++ b/test/models/mapper_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class MapperTest < ActiveSupport::TestCase
   setup do
-    @profile_version = 'core_6-0-0'
+    @profile_version = 'core-6.0.0'
     @connection = Minitest::Mock.new
     @connection.expect :profile, @profile_version
   end

--- a/test/system/users_manager_test.rb
+++ b/test/system/users_manager_test.rb
@@ -4,7 +4,7 @@ require 'application_system_test_case'
 
 class UsersManagerTest < ApplicationSystemTestCase
   setup do
-    sign_in users(:fishmonger)
+    sign_in users(:fruit_n_veg_man)
   end
 
   test 'browse users as manager should be scoped to group (fish) with links' do
@@ -22,4 +22,11 @@ class UsersManagerTest < ApplicationSystemTestCase
     refute_text users(:apple).email
     refute_text users(:brocolli).email
   end
+
+  # TODO
+  # - create a connection & confirm available
+  # - go to create a batch and confirm ok
+  # - change groups
+  # - confirm there are no connections
+  # - confirm cannot create batch
 end


### PR DESCRIPTION
Currently a user's connections are not tied to a particular group,
since that feature was introduced (recently-ish). This is confusing
so now the current group context is applied as the group for a
connection so a user can have different connections for each group
they are a part of.