### PR TITLE
Removes Check records and Check terms checkboxes from Process step

### DIFF
--- a/app/controllers/step/processes_controller.rb
+++ b/app/controllers/step/processes_controller.rb
@@ -69,7 +69,7 @@ module Step
 
     # PARAMS
     def process_params
-      params.require(:step_process).permit(:check_records, :check_terms)
+      {}
     end
   end
 end

--- a/app/models/step/process.rb
+++ b/app/models/step/process.rb
@@ -5,20 +5,6 @@ module Step
     include WorkflowMetadata
     belongs_to :batch
 
-    # after_initialize do |process|
-    #   @config = JSON.parse(process.batch.batch_config)
-    #   process.update(check_terms: false) unless config_check_terms?
-    #   process.update(check_records: false) unless config_check_records?
-    # end
-
-    def check_records?
-      check_records
-    end
-
-    def check_terms?
-      check_terms
-    end
-
     def name
       :processing
     end
@@ -26,19 +12,5 @@ module Step
     def prefix
       :pro
     end
-
-    # def config_check_terms?
-    #   # if not specified in collectionspace-mapper config, defaults to true
-    #   return true unless @config.key?('check_terms')
-    #   # otherwise return boolean value explicitly given in config
-    #   @config['check_terms']
-    # end
-
-    # def config_check_records?
-    #   # if not specified in collectionspace-mapper config, defaults to true
-    #   return true unless @config.key?('check_record_status')
-    #   # otherwise return boolean value explicitly given in config
-    #   @config['check_record_status']
-    # end
   end
 end

--- a/app/views/step/processes/_step.html.erb
+++ b/app/views/step/processes/_step.html.erb
@@ -9,25 +9,17 @@
     <p>The processing step performs the following functions:</p>
     <ul class="mt-2 ml-6 mb-2">
       <li>transforms csv data into collectionspace records</li>
-      <li>searches for existing records (optional*)</li>
-      <li>searches for terms (authority, vocabulary etc.) to use in the generated records (optional*)</li>
-      <li>provides a report on the current state of collectionspace re: the data to be imported</li>
+      <li>determines the current CSpace record status (existing or not (i.e. will be new)) of each record generated</li>
+      <li>translates authority and vocabulary terms into CSpace refnames to provide proper linkage in generated records</li>
+      <li>provides a report of unique authority/vocabulary terms in your data that do not yet exist in CSpace</li>
+      <li>provides a processing report of any potential data issues and current CSpace record status</li>
     </ul>
-    <p class="is-italic">* disable these options if you know the records do not exist (good for 1st time migrations)</p>
   </article>
 <% end %>
 
 <div class="box">
   <%= render layout: 'step/header', locals: { batch: batch, step: step } do |form| %>
-    <%= form.label t('batch.step.process.check_records'), class: 'checkbox is-italic my-1' do %>
-      <%= content_tag :span, class: 'ml-1 mr-1' do t('batch.step.process.check_records') ; end %>
-      <%= form.check_box :check_records, disabled: !batch.ready?, class: 'mr-2' %>
-    <% end %>
-
-    <%= form.label t('batch.step.process.check_terms'), class: 'checkbox is-italic my-1' do %>
-      <%= content_tag :span, class: 'ml-1 mr-1' do t('batch.step.process.check_terms') ; end %>
-      <%= form.check_box :check_terms, disabled: !batch.ready?, class: 'mr-2' %>
-    <% end %>
+    <!-- No additions -->
   <% end %>
 
   <%= render partial: 'step/body', locals: { batch: batch, step: step }%>

--- a/app/views/step/processes/_step.html.erb
+++ b/app/views/step/processes/_step.html.erb
@@ -9,7 +9,7 @@
     <p>The processing step performs the following functions:</p>
     <ul class="mt-2 ml-6 mb-2">
       <li>transforms csv data into collectionspace records</li>
-      <li>determines the current CSpace record status (existing or not (i.e. will be new)) of each record generated</li>
+      <li>determines the current CSpace record status (existing or new) of each record generated</li>
       <li>translates authority and vocabulary terms into CSpace refnames to provide proper linkage in generated records</li>
       <li>provides a report of unique authority/vocabulary terms in your data that do not yet exist in CSpace</li>
       <li>provides a processing report of any potential data issues and current CSpace record status</li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,8 +84,6 @@ en:
         done: Preprocessing has been completed!
       process:
         created: Process job was successfully created
-        check_records: Check for existing records?
-        check_terms: Check for existing terms?
         done: Processing has been completed!
       state:
         ready_message: "Start the %{step} job and receive status updates."

--- a/db/migrate/20210413184444_remove_check_records_from_step_processes.rb
+++ b/db/migrate/20210413184444_remove_check_records_from_step_processes.rb
@@ -1,0 +1,5 @@
+class RemoveCheckRecordsFromStepProcesses < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :step_processes, :check_records, :boolean
+  end
+end

--- a/db/migrate/20210413184509_remove_check_terms_from_step_processes.rb
+++ b/db/migrate/20210413184509_remove_check_terms_from_step_processes.rb
@@ -1,0 +1,5 @@
+class RemoveCheckTermsFromStepProcesses < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :step_processes, :check_terms, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_03_172131) do
+ActiveRecord::Schema.define(version: 2021_04_13_184509) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -153,8 +153,6 @@ ActiveRecord::Schema.define(version: 2020_12_03_172131) do
     t.integer "step_warnings", default: 0
     t.json "messages", default: []
     t.bigint "batch_id", null: false
-    t.boolean "check_records", default: true, null: false
-    t.boolean "check_terms", default: true, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.json "row_results", default: {}

--- a/test/controllers/step/process_controller_test.rb
+++ b/test/controllers/step/process_controller_test.rb
@@ -10,7 +10,7 @@ module Step
       @batch_ready = batches(:superuser_batch_preprocessed) # transition from
       @batch_processed = batches(:superuser_batch_processed) # step finished
       @batch_processed_step = step_processes(:process_superuser_batch)
-      @params = { check_records: false, check_terms: true }
+      @params = {}
     end
 
     test 'a user can access the new process form' do
@@ -26,8 +26,6 @@ module Step
 
       step = Step::Process.last
       assert_redirected_to batch_step_process_url(@batch, step)
-      assert_not step.check_records?
-      assert step.check_terms?
     end
 
     test 'a user is redirected to view if the process step was already run' do


### PR DESCRIPTION
Removes Check records and Check terms checkboxes from Process step, as decided in dev meeting with Megan. Documentation for users starting a migration into a completely empty CSpace will say how to use the JSON batch config to turn this off in the relatively rare case that it is safe to use